### PR TITLE
Randomize Kinesis partition key

### DIFF
--- a/beehive-plenario-sender/plenario-sender.py
+++ b/beehive-plenario-sender/plenario-sender.py
@@ -4,6 +4,7 @@ import os
 import sys
 
 import base64
+import random
 import boto3
 
 sys.path.append(os.path.abspath('../'))
@@ -227,7 +228,7 @@ def callback(ch, method, properties, body):
 
         kinesis_client.put_record(**{
             'StreamName': 'ObservationStream',
-            'PartitionKey': 'arbitrary',
+            'PartitionKey': str(random.random()),
             'Data': json.dumps(payload)
         })
 


### PR DESCRIPTION
The Plenario sender should randomize its Kinesis partition key. Observations with the same key are pushed into the same shard. That is helpful for use cases that need some data to be grouped together (like if we wanted to do rolling window operations on a given sensor type). ([More info here for the curious.](http://docs.aws.amazon.com/streams/latest/dev/key-concepts.html))

But we do no such operations. If we send the same key every time, we can't scale up by adding shards. Randomizing the partition key will make sure observations are evenly distributed across however many shards we need to spin up.