### PR TITLE
fix argument ordering for new version of pika

### DIFF
--- a/beehive-core/Dockerfile
+++ b/beehive-core/Dockerfile
@@ -5,12 +5,10 @@
 #           http://www.wa8.gl
 # ANL:waggle-license
 
-FROM waggle/beehive-core:2
+FROM python:3
 
 WORKDIR /usr/src/app
 
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY loader.py ./
-CMD ["python", "./loader.py"]

--- a/beehive-core/Makefile
+++ b/beehive-core/Makefile
@@ -5,12 +5,9 @@
 #           http://www.wa8.gl
 # ANL:waggle-license
 
-FROM waggle/beehive-core:2
+name = beehive-core
+image = waggle/$(name):2
+include ../Makefile.service
 
-WORKDIR /usr/src/app
-
-COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
-
-COPY loader.py ./
-CMD ["python", "./loader.py"]
+deploy:
+	echo no-op

--- a/beehive-core/README.md
+++ b/beehive-core/README.md
@@ -1,0 +1,5 @@
+<!--
+waggle_topic=/beehive/services
+-->
+
+This is a core definition to build a docker image for the loaders with common dependencies.

--- a/beehive-core/requirements.txt
+++ b/beehive-core/requirements.txt
@@ -1,0 +1,2 @@
+cassandra-driver
+pika>=1.0.0

--- a/beehive-data-loader/Dockerfile
+++ b/beehive-data-loader/Dockerfile
@@ -5,7 +5,7 @@
 #           http://www.wa8.gl
 # ANL:waggle-license
 
-FROM python:3
+FROM waggle/beehive-core:2
 
 WORKDIR /usr/src/app
 

--- a/beehive-data-loader/data-loader
+++ b/beehive-data-loader/data-loader
@@ -150,7 +150,7 @@ def main():
     channel = connection.channel()
 
     channel.queue_declare(queue=queue, durable=True)
-    channel.basic_consume(message_handler, queue)
+    channel.basic_consume(queue, message_handler)
     channel.start_consuming()
 
 

--- a/beehive-data-loader/requirements.txt
+++ b/beehive-data-loader/requirements.txt
@@ -1,3 +1,3 @@
 cassandra-driver
-pika
+pika>=1.0.0
 git+https://github.com/waggle-sensor/pywaggle@v0.25.0

--- a/beehive-loader-raw/loader.py
+++ b/beehive-loader-raw/loader.py
@@ -55,6 +55,6 @@ connection = pika.BlockingConnection(pika.ConnectionParameters(
 
 channel = connection.channel()
 # channel.basic_qos(prefetch_count=1)
-
-channel.basic_consume(process_message, queue='db-raw')
+queue = 'db-raw'
+channel.basic_consume(queue, process_message)
 channel.start_consuming()

--- a/beehive-loader-raw/requirements.txt
+++ b/beehive-loader-raw/requirements.txt
@@ -1,2 +1,2 @@
 cassandra-driver
-pika
+pika>=1.0.0

--- a/beehive-message-router/Dockerfile
+++ b/beehive-message-router/Dockerfile
@@ -5,7 +5,7 @@
 #           http://www.wa8.gl
 # ANL:waggle-license
 
-FROM python:3
+FROM waggle/beehive-core:2
 
 WORKDIR /usr/src/app
 

--- a/beehive-message-router/beehive-message-router
+++ b/beehive-message-router/beehive-message-router
@@ -58,7 +58,7 @@ def main():
     channel = connection.channel()
 
     channel.queue_declare(queue=args.queue, durable=True)
-    channel.basic_consume(message_handler, args.queue)
+    channel.basic_consume(args.queue, message_handler)
     channel.start_consuming()
 
 

--- a/beehive-message-router/requirements.txt
+++ b/beehive-message-router/requirements.txt
@@ -1,2 +1,2 @@
-pika
+pika>=1.0.0
 git+https://github.com/waggle-sensor/pywaggle


### PR DESCRIPTION
ordering of where queue sits changed in pika > 1.0.0 which
pywaggle now requires.  fixed ordering in loader and message
queue scripts and updated requirements to specify >1.0.0 for
pika

Signed-off-by: Eric Van Hensbergen <ericvh@gmail.com>