### PR TITLE
to-router binding needed routing key "#" not ""

### DIFF
--- a/beehive-rabbitmq/configs/definitions.json
+++ b/beehive-rabbitmq/configs/definitions.json
@@ -166,7 +166,7 @@
             "vhost": "/",
             "destination": "to-router",
             "destination_type": "queue",
-            "routing_key": "",
+            "routing_key": "#",
             "arguments": {}
         },
         {


### PR DESCRIPTION
This is a bug introduced when we moved the `messages` exchange from a fanout to a topic exchange. In order to "match everything" in a topic exchange, you need to use the routing key "#" instead of "" like with a fanout.