### PR TITLE
Bug fix data pipeline binding and update to new protocol names

### DIFF
--- a/beehive-data-loader/data-loader.py
+++ b/beehive-data-loader/data-loader.py
@@ -100,8 +100,8 @@ def message_handler(ch, method, properties, body):
         plugin_instance = str(datagram['plugin_instance'])
 
         sub_id = message['sender_sub_id']
-        sensor = str(sensorgram['sensor_id'])
-        parameter = str(sensorgram['parameter_id'])
+        sensor = str(sensorgram['id'])
+        parameter = str(sensorgram['sub_id'])
         value = stringify_value(sensorgram['value'])
 
         csvout.writerow([

--- a/beehive-rabbitmq/configs/definitions.json
+++ b/beehive-rabbitmq/configs/definitions.json
@@ -176,6 +176,14 @@
             "destination_type": "exchange",
             "routing_key": "*.#",
             "arguments": {}
+        },
+        {
+            "source": "to-nodes",
+            "vhost": "/",
+            "destination": "to-node-0000000000000000",
+            "destination_type": "queue",
+            "routing_key": "0000000000000000.#",
+            "arguments": {}
         }
     ]
 }


### PR DESCRIPTION
1. I had to add a default binding for the to-node-0000000000000000. This node ID was a special case and represents a "beehive" node queue. All the data processing tasks are run against this.

2. The v2 data-loader also had to be updated. At some point we changed the protocol fields from `sensor_id` to `id` and `parameter_id` to `sub_id`.